### PR TITLE
Fix package comment

### DIFF
--- a/helm-bbdb.el
+++ b/helm-bbdb.el
@@ -168,9 +168,9 @@ http://bbdb.sourceforge.net/"
 (provide 'helm-bbdb)
 
 ;; Local Variables:
-;; byte-compile-warnings: (not cl-functions obsolete)
+;; byte-compile-warnings: (not obsolete)
 ;; coding: utf-8
 ;; indent-tabs-mode: nil
 ;; End:
 
-;;; helm-bbdb ends here
+;;; helm-bbdb.el ends here


### PR DESCRIPTION
- Correct package footer format
- Remove cl-functions from byte-compile ignore warning because of using
  cl-lib instead of cl.el.